### PR TITLE
ops: add ChatOps bot (slash commands) to automate CI & branch rules

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -1,0 +1,248 @@
+name: ChatOps
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+  discussions: read
+  actions: read
+  administration: write
+
+jobs:
+  chatops:
+    if: >
+      github.event_name == 'issue_comment' &&
+      contains(github.event.comment.body, '/')
+    runs-on: ubuntu-latest
+    env:
+      REPO: ${{ github.repository }}
+      OWNER: ${{ github.repository_owner }}
+      CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}
+      COMMENT_BODY: ${{ github.event.comment.body }}
+      AUTHOR_ASSOC: ${{ github.event.comment.author_association }}
+
+    steps:
+      - name: Authorize caller (owner/member/collaborator only)
+        run: |
+          case "${AUTHOR_ASSOC}" in
+            OWNER|MEMBER|COLLABORATOR) echo "Authorized" ;;
+            *) echo "Not authorized: ${AUTHOR_ASSOC}"; exit 1 ;;
+          esac
+
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CHATOPS_TOKEN }}
+          ref: ${{ github.event.repository.default_branch }}
+
+      # -------------------------------
+      # /bootstrap-ci  -> creates files and opens PR
+      # -------------------------------
+      - name: Bootstrap CI (create files & PR)
+        if: contains(env.COMMENT_BODY, '/bootstrap-ci')
+        run: |
+          set -e
+          mkdir -p .github/workflows
+
+          cat > .github/workflows/ci.yml <<'YAML'
+          name: CI
+          on:
+            pull_request:
+              types: [opened, synchronize, reopened, ready_for_review]
+            push:
+              branches: [main]
+            workflow_dispatch:
+          permissions:
+            contents: read
+          jobs:
+            smoke:
+              name: Smoke
+              runs-on: ubuntu-latest
+              steps:
+                - name: Checkout
+                  uses: actions/checkout@v4
+                - name: Sanity ping
+                  run: echo "✅ Smoke check running"
+                - name: Detect Node project
+                  id: detect_node
+                  run: |
+                    if [ -f package.json ]; then
+                      echo "node_project=true" >> $GITHUB_OUTPUT
+                    else
+                      echo "node_project=false" >> $GITHUB_OUTPUT
+                    fi
+                - name: Setup Node
+                  if: steps.detect_node.outputs.node_project == 'true'
+                  uses: actions/setup-node@v4
+                  with:
+                    node-version: '20'
+                    cache: 'npm'
+                - name: Install deps (Node)
+                  if: steps.detect_node.outputs.node_project == 'true'
+                  run: |
+                    if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+                      npm ci
+                    else
+                      npm install
+                    fi
+                - name: Lint (if present)
+                  if: steps.detect_node.outputs.node_project == 'true'
+                  run: npm run --if-present lint
+                - name: Build (if present)
+                  if: steps.detect_node.outputs.node_project == 'true'
+                  run: npm run --if-present build
+
+            repo_health:
+              name: Repo Health
+              runs-on: ubuntu-latest
+              steps:
+                - name: Checkout
+                  uses: actions/checkout@v4
+                - name: Basic repo checks
+                  run: |
+                    set -e
+                    test -f CODEOWNERS || (echo "❌ Missing CODEOWNERS at repo root"; exit 1)
+                    echo "✅ CODEOWNERS present"
+                - name: Setup Python
+                  uses: actions/setup-python@v5
+                  with:
+                    python-version: '3.x'
+                - name: Install pre-commit
+                  run: pip install pre-commit
+                - name: Run pre-commit
+                  run: pre-commit run --all-files --show-diff-on-failure
+          YAML
+
+          cat > .pre-commit-config.yaml <<'YAML'
+          repos:
+            - repo: https://github.com/pre-commit/pre-commit-hooks
+              rev: v4.6.0
+              hooks:
+                - id: trailing-whitespace
+                - id: end-of-file-fixer
+                - id: mixed-line-ending
+                - id: check-yaml
+                - id: check-json
+                - id: check-added-large-files
+            - repo: https://github.com/astral-sh/ruff-pre-commit
+              rev: v0.6.2
+              hooks:
+                - id: ruff
+                  args: [--fix]
+            - repo: https://github.com/pre-commit/mirrors-prettier
+              rev: v3.3.3
+              hooks:
+                - id: prettier
+          YAML
+
+          mkdir -p .github
+          cat > .github/dependabot.yml <<'YAML'
+          version: 2
+          updates:
+            - package-ecosystem: "github-actions"
+              directory: "/"
+              schedule:
+                interval: "weekly"
+            - package-ecosystem: "npm"
+              directory: "/"
+              schedule:
+                interval: "weekly"
+          YAML
+
+          cat > .github/workflows/auto-merge-dependabot.yml <<'YAML'
+          name: Auto-merge Dependabot
+          on:
+            pull_request_target:
+              types: [opened, synchronize, reopened, ready_for_review]
+          permissions:
+            pull-requests: write
+            contents: write
+          jobs:
+            enable-auto-merge:
+              if: github.actor == 'dependabot[bot]'
+              runs-on: ubuntu-latest
+              steps:
+                - name: Fetch metadata
+                  id: meta
+                  uses: dependabot/fetch-metadata@v2
+                - name: Enable auto-merge (squash)
+                  if: steps.meta.outputs.update-type != 'version-update:semver-major'
+                  uses: peter-evans/enable-pull-request-automerge@v3
+                  with:
+                    token: ${{ secrets.GITHUB_TOKEN }}
+                    merge-method: squash
+          YAML
+
+          git config user.name "milkbox-ai-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git checkout -b bot/bootstrap-ci
+          git add .
+          git commit -m "ci: bootstrap CI (Smoke & Repo Health), pre-commit, Dependabot, auto-merge"
+          git push -u origin bot/bootstrap-ci
+
+      - name: Open PR for bootstrap
+        if: contains(env.COMMENT_BODY, '/bootstrap-ci')
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.CHATOPS_TOKEN }}
+          branch: bot/bootstrap-ci
+          title: "ci: register 'Smoke' & 'Repo Health'; add pre-commit + Dependabot"
+          body: |
+            - Adds named checks **Smoke** and **Repo Health**
+            - Adds `.pre-commit-config.yaml`
+            - Adds Dependabot (actions + npm)
+            - Adds auto-merge for Dependabot (non-major)
+            Merge this, then set them as required checks.
+
+      # -------------------------------
+      # /set-required-checks  -> branch rules
+      # -------------------------------
+      - name: Set branch protection (main)
+        if: contains(env.COMMENT_BODY, '/set-required-checks')
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CHATOPS_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = 'main';
+            await github.request('PUT /repos/{owner}/{repo}/branches/{branch}/protection', {
+              owner, repo, branch,
+              required_status_checks: {
+                strict: true,
+                contexts: ['Smoke','Repo Health'],
+              },
+              enforce_admins: false,
+              required_pull_request_reviews: { required_approving_review_count: 1 },
+              restrictions: null
+            });
+
+      # -------------------------------
+      # /open-test-pr  -> tiny PR to prove gating
+      # -------------------------------
+      - name: Open test PR (branch + commit)
+        if: contains(env.COMMENT_BODY, '/open-test-pr')
+        run: |
+          set -e
+          git config user.name "milkbox-ai-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git checkout -b bot/test-pr
+          date > .ci_proof
+          git add .ci_proof
+          git commit -m "chore: trigger CI to prove required checks"
+          git push -u origin bot/test-pr
+
+      - name: Create PR (test)
+        if: contains(env.COMMENT_BODY, '/open-test-pr')
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.CHATOPS_TOKEN }}
+          branch: bot/test-pr
+          title: "chore: CI proof PR"
+          body: "No-op change to trigger **Smoke** & **Repo Health**."


### PR DESCRIPTION
Adds a ChatOps workflow that responds to repo comments:
- /bootstrap-ci -> opens PR adding CI (Smoke & Repo Health), pre-commit, Dependabot, auto-merge
- /set-required-checks -> sets branch protection for main with required checks (Smoke, Repo Health)
- /open-test-pr -> opens a tiny PR to prove required checks gate merges

Uses a PAT stored as Actions secret CHATOPS_TOKEN with repo scope.

## Summary
<!-- What does this PR change? -->

## Checklist
- [ ] Smoke (Imports) green on this PR
- [ ] Repo Health green (warnings OK if intentional)
- [ ] No secrets or credentials added
- [ ] If new Python folders were added, `__init__.py` exists (Repo Steward should handle this)

## Screenshots / Logs (optional)
