### PR TITLE
ops: avoid secret-scanning false positive in auto-merge workflow

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -149,6 +149,7 @@ jobs:
                 interval: "weekly"
           YAML
 
+          # IMPORTANT: no explicit 'token:' here to avoid Secret Scanning push-protection false positives
           cat > .github/workflows/auto-merge-dependabot.yml <<'YAML'
           name: Auto-merge Dependabot
           on:
@@ -169,7 +170,6 @@ jobs:
                   if: steps.meta.outputs.update-type != 'version-update:semver-major'
                   uses: peter-evans/enable-pull-request-automerge@v3
                   with:
-                    token: ${{ secrets.GITHUB_TOKEN }}
                     merge-method: squash
           YAML
 


### PR DESCRIPTION
Secret Scanning Push Protection flagged the generated file `.github/workflows/auto-merge-dependabot.yml` as a “GitHub App Installation Access Token” when an explicit `token: ${{ secrets.GITHUB_TOKEN }}` is present. This is a false positive and blocks ChatOps pushes.

Change:
- Remove the explicit `token:` input; the action uses GITHUB_TOKEN by default.
- Keep /bootstrap-ci, /set-required-checks, /open-test-pr unchanged.

This prevents future push-protection blocks while preserving functionality.

## Summary
<!-- What does this PR change? -->

## Checklist
- [ ] Smoke (Imports) green on this PR
- [ ] Repo Health green (warnings OK if intentional)
- [ ] No secrets or credentials added
- [ ] If new Python folders were added, `__init__.py` exists (Repo Steward should handle this)

## Screenshots / Logs (optional)
