### PR TITLE
ci(chatops): stop deleting test-pr branch; always reuse or reopen sin…

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -7,26 +7,25 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: read
+  issues: write
   discussions: read
   actions: read
 
 jobs:
   chatops:
-    # Only react to slash commands in comments
     if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/')
     runs-on: ubuntu-latest
 
-    # Prevent overlapping runs on the same issue/PR from racing each other
+    # Prevent races on the same issue/PR
     concurrency:
       group: chatops-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number || 'na' }}
       cancel-in-progress: false
 
     env:
-      REPO: ${{ github.repository }}
-      OWNER: ${{ github.repository_owner }}
+      REPO: ${{ github.repository }}                       # owner/repo
+      OWNER: ${{ github.repository_owner }}                # owner
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-      CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}   # PAT with repo admin perms (for branch protection + pushes)
+      CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}
       COMMENT_BODY: ${{ github.event.comment.body }}
       AUTHOR_ASSOC: ${{ github.event.comment.author_association }}
 
@@ -38,7 +37,7 @@ jobs:
             *) echo "Not authorized: ${AUTHOR_ASSOC}"; exit 1;;
           esac
 
-      - name: Checkout default branch (full history; no auto creds)
+      - name: Checkout default branch (full history; no auto-creds)
         uses: actions/checkout@v4
         with:
           ref: ${{ env.DEFAULT_BRANCH }}
@@ -52,7 +51,7 @@ jobs:
           git remote set-url origin "https://x-access-token:${CHATOPS_TOKEN}@github.com/${REPO}.git"
 
       # -------------------------------
-      # /bootstrap-ci -> create CI, pre-commit, Dependabot, auto-merge; open PR
+      # /bootstrap-ci
       # -------------------------------
       - name: Bootstrap CI (create files & PR branch)
         if: contains(env.COMMENT_BODY, '/bootstrap-ci')
@@ -72,7 +71,7 @@ jobs:
             contents: read
           jobs:
             smoke:
-              name: Smoke
+              name: Smoke (Imports)
               runs-on: ubuntu-latest
               steps:
                 - uses: actions/checkout@v4
@@ -185,7 +184,6 @@ jobs:
                     merge-method: squash
           YAML
 
-          # Create or reset the branch safely, commit defensively, push with PAT
           git switch -C bot/bootstrap-ci
           git add -A
           if git diff --cached --quiet; then
@@ -199,94 +197,107 @@ jobs:
         if: contains(env.COMMENT_BODY, '/bootstrap-ci')
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ github.token }}   # safe to use GITHUB_TOKEN for opening PRs
+          token: ${{ github.token }}
           base: ${{ env.DEFAULT_BRANCH }}
           branch: bot/bootstrap-ci
-          title: "ci: register 'Smoke' & 'Repo Health'; add pre-commit + Dependabot"
-          body: |
-            This PR was opened by **ChatOps**.
-
-            **Adds**
-            - Named checks: **Smoke** and **Repo Health**
-            - `.pre-commit-config.yaml`
-            - Dependabot (actions + npm)
-            - Auto-merge for Dependabot (non-major)
-
-            Merge this first, then run `/set-required-checks` in the **Ops Console** issue.
+          title: "ci: register 'Smoke (Imports)' & 'Repo Health'; add pre-commit + Dependabot"
+          body: "Opened by ChatOps."
 
       # -------------------------------
-      # /set-required-checks -> branch protection on main
+      # /set-required-checks
       # -------------------------------
       - name: Set branch protection (main)
         if: contains(env.COMMENT_BODY, '/set-required-checks')
         uses: actions/github-script@v7
         with:
-          github-token: ${{ env.CHATOPS_TOKEN }}   # PAT must have repo admin perms
+          github-token: ${{ env.CHATOPS_TOKEN }}
           script: |
             const owner  = context.repo.owner;
             const repo   = context.repo.repo;
             const branch = context.payload.repository.default_branch || 'main';
-
-            try {
-              await github.request('PUT /repos/{owner}/{repo}/branches/{branch}/protection', {
-                owner, repo, branch,
-                required_status_checks: {
-                  strict: true,
-                  contexts: ['Smoke','Repo Health'],
-                },
-                enforce_admins: false,
-                required_pull_request_reviews: { required_approving_review_count: 1 },
-                restrictions: null
-              });
-              core.info(`Branch protection updated on ${branch}`);
-            } catch (e) {
-              core.setFailed(`Failed to set branch protection: ${e.message}`);
-            }
+            await github.request('PUT /repos/{owner}/{repo}/branches/{branch}/protection', {
+              owner, repo, branch,
+              required_status_checks: {
+                strict: true,
+                contexts: ['Smoke (Imports) / smoke (pull_request)', 'Repo Health / health (pull_request)'],
+              },
+              enforce_admins: false,
+              required_pull_request_reviews: { required_approving_review_count: 1 },
+              restrictions: null
+            });
 
       # -------------------------------
-      # /open-test-pr -> tiny PR to prove gating (idempotent)
+      # /open-test-pr  (REUSE/REOPEN PR; never delete branch if PR open)
       # -------------------------------
       - name: Prepare bot/test-pr from origin/main (always reset)
         if: contains(env.COMMENT_BODY, '/open-test-pr')
         run: |
-          set -eo pipefail
+          set -euo pipefail
           git fetch origin --prune
           git checkout -B bot/test-pr "origin/${DEFAULT_BRANCH}"
-
           mkdir -p .github
           echo "Refreshed: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" > .github/test-pr.txt
           git add .github/test-pr.txt
-          # Allow empty commit if the timestamp happens to match (rare)
           git commit -m "chore(test-pr): refresh automated test PR" || true
 
-      - name: Best-effort remove remote ref first (avoids stale refs)
+      - name: Push branch (force-with-lease; retry; DO NOT delete if open PR exists)
         if: contains(env.COMMENT_BODY, '/open-test-pr')
         env:
           GH_TOKEN: ${{ env.CHATOPS_TOKEN }}
         run: |
-          gh api --method DELETE repos/${REPO}/git/refs/heads/bot/test-pr || true
-
-      - name: Push branch (force-with-lease; retry once)
-        if: contains(env.COMMENT_BODY, '/open-test-pr')
-        run: |
-          set -e
+          set -euo pipefail
           git fetch origin --prune
-          if ! git push --force-with-lease origin HEAD:bot/test-pr; then
-            echo "Lease changed; refetching and retrying..."
+          if git push --force-with-lease origin HEAD:bot/test-pr; then
+            exit 0
+          fi
+          echo "First push failed; checking for an open PR…"
+          owner="${OWNER}"
+          repo="${REPO#*/}"
+          open=$(gh api -X GET "repos/${owner}/${repo}/pulls?state=open&head=${owner}:bot/test-pr" -q '.[0].number' || true)
+          if [ -n "${open:-}" ]; then
+            echo "Open PR #${open} exists; NOT deleting remote branch. Retrying push…"
+            git fetch origin --prune
+            git push --force-with-lease origin HEAD:bot/test-pr
+          else
+            echo "No open PR; deleting remote branch as a last resort and retrying…"
+            gh api --method DELETE "repos/${REPO}/git/refs/heads/bot/test-pr" || true
             git fetch origin --prune
             git push --force-with-lease origin HEAD:bot/test-pr
           fi
 
-      - name: Create or update PR pointing to main
+      - name: Create or update PR (reuse if open; reopen if closed)
         if: contains(env.COMMENT_BODY, '/open-test-pr')
         env:
           GH_TOKEN: ${{ env.CHATOPS_TOKEN }}
         run: |
-          set -e
-          num=$(gh pr list --head bot/test-pr --json number -q '.[0].number' || true)
-          if [ -n "$num" ]; then
-            gh pr edit "$num" --title "Test PR (bot)" --body "Automated test PR refreshed by ChatOps."
-            echo "Updated existing PR #$num"
-          else
-            gh pr create --title "Test PR (bot)" --body "Automated test PR from ChatOps." --base "${DEFAULT_BRANCH}" --head bot/test-pr
+          set -euo pipefail
+          owner="${OWNER}"
+          repo="${REPO#*/}"
+          # 1) Prefer existing OPEN PR by exact head
+          num=$(gh api -X GET "repos/${owner}/${repo}/pulls?state=open&head=${owner}:bot/test-pr" -q '.[0].number' || true)
+          if [ -z "${num:-}" ]; then
+            # 2) If none open, reopen the most recent CLOSED (not merged) PR for this head
+            num=$(gh api -X GET "repos/${owner}/${repo}/pulls?state=closed&head=${owner}:bot/test-pr&sort=updated&direction=desc" -q 'map(select(.merged_at==null)) | .[0].number' || true)
+            if [ -n "${num:-}" ]; then
+              echo "Reopening closed PR #$num"
+              gh pr reopen "$num"
+            fi
           fi
+          if [ -n "${num:-}" ]; then
+            gh pr edit "$num" --title "Test PR (bot)" --body "Automated test PR refreshed by ChatOps."
+          else
+            num=$(gh pr create --title "Test PR (bot)" --body "Automated test PR from ChatOps." --base "${DEFAULT_BRANCH}" --head bot/test-pr --json number -q .number)
+          fi
+          echo "PR_NUMBER=$num" >> $GITHUB_ENV
+          url=$(gh pr view "$num" --json url -q .url)
+          echo "PR_URL=$url" >> $GITHUB_ENV
+          echo "Opened/updated PR #$num: $url"
+
+      - name: Comment result back to this issue
+        if: contains(env.COMMENT_BODY, '/open-test-pr')
+        env:
+          GH_TOKEN: ${{ env.CHATOPS_TOKEN }}
+        run: |
+          issue="${{ github.event.issue.number }}"
+          sha=$(git rev-parse --short HEAD)
+          gh api "repos/${REPO}/issues/${issue}/comments" -f body="✅ Test PR refreshed.\n\n- PR: ${PR_URL}\n- Commit: \`${sha}\`"


### PR DESCRIPTION
…gle Test PR and comment back

- Remove remote-ref deletion that closed the existing PR and caused #23 → #24 → #25 churn.
- Push with --force-with-lease; if push fails and an open PR exists, retry without deleting the branch.
- PR handling: • Reuse existing open PR (head = OWNER:bot/test-pr) • If none open, reopen latest closed (not merged) PR for the same head • Only create a new PR when none exist to reuse/reopen
- Post result back to the Ops Console issue with PR URL and short commit.
- /set-required-checks writes exact contexts: Smoke (Imports) / smoke (pull_request) Repo Health / health (pull_request)

## Summary
<!-- What does this PR change? -->

## Checklist
- [ ] Smoke (Imports) green on this PR
- [ ] Repo Health green (warnings OK if intentional)
- [ ] No secrets or credentials added
- [ ] If new Python folders were added, `__init__.py` exists (Repo Steward should handle this)

## Screenshots / Logs (optional)
