### PR TITLE
fix(streamlit): import Dict/Any for type annotations (NameError at ap…

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 # --- Ensure "tools.*" imports resolve ---
 import sys
 from pathlib import Path


### PR DESCRIPTION
…p.py:20)

Add 'from typing import Any, Dict' so the annotation 'Dict[str, Any]' doesn't crash at import-time.

## Summary
<!-- What does this PR change? -->

## Checklist
- [ ] Smoke (Imports) green on this PR
- [ ] Repo Health green (warnings OK if intentional)
- [ ] No secrets or credentials added
- [ ] If new Python folders were added, `__init__.py` exists (Repo Steward should handle this)

## Screenshots / Logs (optional)
